### PR TITLE
fix(style): open sans not available on all systems

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    font-family: 'Open Sans';
+    font-family: 'Open Sans', sans-serif;
     overflow-x: hidden;
 }


### PR DESCRIPTION
Either use google fonts or define fallback.

Right now it looks like this:
![image](https://cloud.githubusercontent.com/assets/123822/23177375/6df35796-f81b-11e6-803d-29113ac4c5fb.png)
